### PR TITLE
Taking into account the cluster name, if configured.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -56,7 +56,11 @@ else
     echo "waiting for Elasticsearch to be up ($counter/30)"
   done
 
-  OUTPUT_LOGFILES+="/var/log/elasticsearch/elasticsearch.log "
+  CLUSTER_NAME=$(grep -Po '(?<=^cluster.name: ).*' /etc/elasticsearch/elasticsearch.yml | sed -e 's/^[ \t]*//;s/[ \t]*$//')
+  if [ -z "$CLUSTER_NAME" ]; then
+     CLUSTER_NAME=elasticsearch
+  fi
+  OUTPUT_LOGFILES+="/var/log/elasticsearch/${CLUSTER_NAME}.log "
 fi
 
 # Logstash


### PR DESCRIPTION
The log file for Elasticsearch is based on the cluster name, which is `elasticsearch` by default.

If that cluster name is changed, the `tail` command at the end of `start.sh` will fail to find the correct file (and the container won't start properly if it's the only log file in use).

This patch looks for the `cluster.name` option in `/etc/elasticsearch/elasticsearch.yml`, to adapt the log file name automatically. Hopefully, this should make it easier to change the cluster name.

(If the option is not set in the config file, it will fall back to the default value.)