### PR TITLE
Add ability to override ES max mem

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,11 @@ fi
 if [ "$ELASTICSEARCH_START" -ne "1" ]; then
   echo "ELASTICSEARCH_START is set to something different from 1, not starting..."
 else
+  # override ES_MAX_MEM variable if set
+  if [ ! -z "$ES_MAX_MEM" ]; then
+    sed -i -e 's#^    ES_MAX_MEM=[0-9].*$#    ES_MAX_MEM='$ES_MAX_MEM'#' /usr/share/elasticsearch/bin/elasticsearch.in.sh
+  fi
+
   service elasticsearch start
 
   # wait for Elasticsearch to start up before either starting Kibana (if enabled)


### PR DESCRIPTION
This PR has the addition of allowing one to override the Elasticsearch max memory setting, in the same way the logstash settings are overridden below.

It seems brittle but my sed isn't good enough to do better.

PS my first PR, hope I did it correctly.