### PR TITLE
Es max mem

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,10 @@ fi
 if [ "$ELASTICSEARCH_START" -ne "1" ]; then
   echo "ELASTICSEARCH_START is set to something different from 1, not starting..."
 else
+  # override ES_HEAP_SIZE variable if set
+  if [ ! -z "$ES_HEAP_SIZE" ]; then
+    sed -i -e 's/^#ES_HEAP_SIZE=[0-9].*$/ES_HEAP_SIZE='$ES_HEAP_SIZE'/' /etc/default/elasticsearch
+  fi
   # override ES_MAX_MEM variable if set
   if [ ! -z "$ES_MAX_MEM" ]; then
     sed -i -e 's#^    ES_MAX_MEM=[0-9].*$#    ES_MAX_MEM='$ES_MAX_MEM'#' /usr/share/elasticsearch/bin/elasticsearch.in.sh

--- a/start.sh
+++ b/start.sh
@@ -44,6 +44,11 @@ fi
 if [ "$ELASTICSEARCH_START" -ne "1" ]; then
   echo "ELASTICSEARCH_START is set to something different from 1, not starting..."
 else
+  # override ES_MAX_MEM variable if set
+  if [ ! -z "$ES_MAX_MEM" ]; then
+    sed -i -e 's#^    ES_MAX_MEM=[0-9].*$#    ES_MAX_MEM='$ES_MAX_MEM'#' /usr/share/elasticsearch/bin/elasticsearch.in.sh
+  fi
+
   service elasticsearch start
 
   # wait for Elasticsearch to start up before either starting Kibana (if enabled)


### PR DESCRIPTION
I've updated the start.sh.

I added the ability to overwrite ES_HEAP_SIZE and tested.  It works fine.

I left the ES_MAX_MEM as it was; there's no other place to override that property except elasticsearch.bin.sh.  Also, I still think there's a use case for only setting Xmx.  I did not add a similar line for ES_MIN_MEM because I doubt that's an interesting use case (outside of ES_HEAP_SIZE, which sets both).

I think you can take it as it is, remove the ES_MAX_MEM, or add an ES_MIN_MEM to match.  Either way, it's fine.

Cheers!