### PR TITLE
Changed the Kibana version to 4.6.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ RUN sed -i -e 's#^LS_HOME=$#LS_HOME='$LOGSTASH_HOME'#' /etc/init.d/logstash \
 
 ### install Kibana
 
-ENV KIBANA_VERSION 4.6.0
+ENV KIBANA_VERSION 4.6.1
 ENV KIBANA_HOME /opt/kibana
 ENV KIBANA_PACKAGE kibana-${KIBANA_VERSION}-linux-x86_64.tar.gz
 ENV KIBANA_GID 993

--- a/README-short.txt
+++ b/README-short.txt
@@ -1,1 +1,1 @@
-Collect, search and visualise log data with ELK (Elasticsearch 2.4.0, Logstash 2.4.0, Kibana 4.6.0).
+Collect, search and visualise log data with ELK (Elasticsearch 2.4.0, Logstash 2.4.0, Kibana 4.6.1).

--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ This Docker image provides a convenient centralised log server and log managemen
 
 The following tags are available:
 
-- `es240_l240_k460`, `latest`: Elasticsearch 2.4.0, Logstash 2.4.0, and Kibana 4.6.0.
+
+- `es240_l240_k461`, `latest`: Elasticsearch 2.4.0, Logstash 2.4.0, and Kibana 4.6.1.
+
+- `es240_l240_k460`: Elasticsearch 2.4.0, Logstash 2.4.0, and Kibana 4.6.0.
 
 - `es235_l234_k454`: Elasticsearch 2.3.5, Logstash 2.3.4, and Kibana 4.5.4.
 


### PR DESCRIPTION
I increased the kibana version to get the bugfix for [#8141 Unable to order aggs by _term after upgrade to 4.6.0 ](https://github.com/elastic/kibana/issues/8141) .