### PR TITLE
Removed duplicate "Elasticsearch" and re-ordered

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -579,7 +579,7 @@ For instance, with the default configuration files in the image, replace the con
 
 ## Troubleshooting <a name="troubleshooting"></a>
 
-**Important** – If you need help to troubleshoot the configuration of Elasticsearch, Kibana, or Elasticsearch, regardless of where the services are running (in a Docker container or not), please head over to the [Elastic forums](https://discuss.elastic.co/). The troubleshooting guidelines below only apply to the running a container using the ELK Docker image.
+**Important** – If you need help to troubleshoot the configuration of Elasticsearch, Logstash, or Kibana, regardless of where the services are running (in a Docker container or not), please head over to the [Elastic forums](https://discuss.elastic.co/). The troubleshooting guidelines below only apply to the running a container using the ELK Docker image.
 
 Here are a few pointers to help you troubleshoot your containerised ELK.
 


### PR DESCRIPTION
Changed :

"_Elasticsearch, Kibana, or Elasticsearch..._"

to

"_Elasticsearch, Logstash, or Kibana_"

(This is the proper version, superseding https://github.com/spujadas/elk-docker/pull/80 )