### PR TITLE
issues #99: We shouldn't start sysctl if vm.max_map_count is correct

### DIFF
--- a/elasticsearch-init
+++ b/elasticsearch-init
@@ -133,7 +133,7 @@ case "$1" in
             ulimit -l $MAX_LOCKED_MEMORY
         fi
 
-        if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count ]; then
+	if [ -n "$MAX_MAP_COUNT" -a -f /proc/sys/vm/max_map_count -a "$MAX_MAP_COUNT" -gt $(cat /proc/sys/vm/max_map_count) ]; then
             sysctl -q -w vm.max_map_count=$MAX_MAP_COUNT
         fi
 


### PR DESCRIPTION
I have this trouble too with latest version. I made patch for it. It work for me