### PR TITLE
Change type of "bytes" and "response" to int in nginx pattern

### DIFF
--- a/nginx.pattern
+++ b/nginx.pattern
@@ -1,3 +1,3 @@
 NGUSERNAME [a-zA-Z\.\@\-\+_%]+
 NGUSER %{NGUSERNAME}
-NGINXACCESS %{IPORHOST:clientip} %{NGUSER:ident} %{NGUSER:auth} \[%{HTTPDATE:timestamp}\] "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}" %{NUMBER:response} (?:%{NUMBER:bytes}|-) (?:"(?:%{URI:referrer}|-)"|%{QS:referrer}) %{QS:agent}
+NGINXACCESS %{IPORHOST:clientip} %{NGUSER:ident} %{NGUSER:auth} \[%{HTTPDATE:timestamp}\] "%{WORD:verb} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}" %{NUMBER:response:int} (?:%{NUMBER:bytes:int}|-) (?:"(?:%{URI:referrer}|-)"|%{QS:referrer}) %{QS:agent}


### PR DESCRIPTION
The field "bytes" should always be an int. The field "response" should be typed as int (it is a "3 digit int" as the standard says https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html).

Doing these changes helps to do queries like summing the bytes sent or querying for all "response"s (status codes) > 399