### PR TITLE
set heap size in jvm.options file

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -59,8 +59,10 @@ if [ "$ELASTICSEARCH_START" -ne "1" ]; then
 else
   # override ES_HEAP_SIZE variable if set
   if [ ! -z "$ES_HEAP_SIZE" ]; then
-    awk -v LINE="ES_HEAP_SIZE=\"$ES_HEAP_SIZE\"" '{ sub(/^#?ES_HEAP_SIZE=.*/, LINE); print; }' /etc/default/elasticsearch \
-        > /etc/default/elasticsearch.new && mv /etc/default/elasticsearch.new /etc/default/elasticsearch
+    awk -v LINE="-Xmx$ES_HEAP_SIZE" '{ sub(/^.Xmx.*/, LINE); print; }' /etc/elasticsearch/jvm.options \
+        > /etc/elasticsearch/jvm.options.new && mv /etc/elasticsearch/jvm.options.new /etc/elasticsearch/jvm.options
+    awk -v LINE="-Xms$ES_HEAP_SIZE" '{ sub(/^.Xms.*/, LINE); print; }' /etc/elasticsearch/jvm.options \
+        > /etc/elasticsearch/jvm.options.new && mv /etc/elasticsearch/jvm.options.new /etc/elasticsearch/jvm.options
   fi
   # override ES_JAVA_OPTS variable if set
   if [ ! -z "$ES_JAVA_OPTS" ]; then


### PR DESCRIPTION
With the new changes in Elasticsearch, the JVM options are no longer set in /etc/default/elasticsearch, but instead in /etc/elasticsearch/jvm.options.  I've repurposed our old trick of awk-ing the file with params pulled at runtime, because it's always useful to be able to adjust the heap that Elasticsearch is using without having to build a new Docker image.

I'm not sure about the ES_JAVA_OPTS; it still exists in /etc/default/elasticsearch, but I think that might be an omission in Elasticsearch; surely the jvm.options file takes the place of that.  In any event, I left that awk statement in start.sh just in case it's still useful.