### PR TITLE
Upgrade to 6.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Dockerfile for ELK stack
-# Elasticsearch, Logstash, Kibana 6.2.1
+# Elasticsearch, Logstash, Kibana 6.2.2
 
 # Build with:
 # docker build -t <repo-user>/elk .
@@ -9,7 +9,7 @@
 
 FROM phusion/baseimage
 MAINTAINER Sebastien Pujadas http://pujadas.net
-ENV REFRESHED_AT 2017-01-13
+ENV REFRESHED_AT 2017-02-28
 
 
 ###############################################################################
@@ -39,7 +39,7 @@ RUN set -x \
  && set +x
 
 
-ENV ELK_VERSION 6.2.1
+ENV ELK_VERSION 6.2.2
 
 ### install Elasticsearch
 


### PR DESCRIPTION
6.2.1 has a major bug in the X-pack email notifier (does not work at all, see https://www.elastic.co/guide/en/elasticsearch/reference/current/xes-6.2.2.html), so the upgrade to 6.2.2 is highly anticipated...