### PR TITLE
Ensure time zone override applies to Logstash

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -36,6 +36,12 @@ rm -f /var/run/elasticsearch/elasticsearch.pid /var/run/logstash.pid \
 OUTPUT_LOGFILES=""
 
 
+## override default time zone (Etc/UTC) if TZ variable is set
+if [ ! -z "$TZ" ]; then
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+fi
+
+
 ## run pre-hooks
 if [ -x /usr/local/bin/elk-pre-hooks.sh ]; then
   . /usr/local/bin/elk-pre-hooks.sh


### PR DESCRIPTION
As part of adding tzdata pkg in spujadas/elk-docker@52b3996, the start
script was modified to [remove overriding the time zone via symlink of
`/etc/localtime` & writing to `/etc/timezone`](https://github.com/spujadas/elk-docker/commit/52b3996#diff-d0b2ef35f4d7cb0284dd5cf566b62f51).

While the default system timezone is successfully overridden via the
`TZ` environment variable alone, local testing reveals that without
these additional measures above, a script running as part of a Logstash
[ruby filter plugin](https://www.elastic.co/guide/en/logstash/current/plugins-filters-ruby.html) is unaware of the override and returns the
default UTC for `Time.now.localtime.zone`.
