### PR TITLE
Creates the filebeat template dynamically (and associated to the corr…

### DIFF
--- a/nginx-filebeat/Dockerfile
+++ b/nginx-filebeat/Dockerfile
@@ -51,6 +51,9 @@ RUN chmod 644 /etc/filebeat/filebeat.yml
 RUN mkdir -p /etc/pki/tls/certs
 ADD logstash-beats.crt /etc/pki/tls/certs/logstash-beats.crt
 
+# create template based on filebeat version (assumption: it is the same version as elasticsearch version)
+RUN filebeat export template --es.version ${FILEBEAT_VERSION} > /etc/filebeat/filebeat.template.json
+
 ###############################################################################
 #                                    DATA
 ###############################################################################

--- a/nginx-filebeat/start.sh
+++ b/nginx-filebeat/start.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-curl -XPUT 'http://elk:9200/_template/filebeat?pretty' -d@/etc/filebeat/filebeat.template.json
+curl -XPUT -H "Content-Type: application/json" 'http://elk:9200/_template/filebeat?pretty' -d@/etc/filebeat/filebeat.template.json
 /etc/init.d/filebeat start
 nginx
 tail -f /var/log/nginx/access.log -f /var/log/nginx/error.log


### PR DESCRIPTION
Fixes #228 - now creating the template at build time in the Dockerfile before that start.sh can send it to elk at startup of nginx.