### PR TITLE
change filebeat.prospectors to filebeat.inputs

### DIFF
--- a/nginx-filebeat/filebeat.yml
+++ b/nginx-filebeat/filebeat.yml
@@ -9,7 +9,7 @@ output:
       - /etc/pki/tls/certs/logstash-beats.crt
 
 filebeat:
-  prospectors:
+  inputs:
     -
       paths:
         - /var/log/syslog


### PR DESCRIPTION
Running the nginx-filebeat sample project results in filebeat crashing on boot.

Per https://github.com/elastic/logstash/pull/10683, it appears that prospectors has been renamed to inputs. Making this change allows the sample project to run without filebeat crashing.