### PR TITLE
update to ubuntu18, tweaks for speed

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -137,7 +137,7 @@ else
     echo "Waiting for Elasticsearch cluster to respond ($counter/30)"
   done
   if [ -z "$CLUSTER_NAME" ]; then
-    echo "Couln't get name of cluster. Exiting."
+    echo "Couldn't get name of cluster. Exiting."
     echo "Elasticsearch log follows below."
     cat /var/log/elasticsearch/elasticsearch.log
     exit 1


### PR DESCRIPTION
- update to phusion 11, which is ubuntu 1804. 1604 is dated at this point.
- combine the ENV lines to cut down on docker layers. I kept them organized by 'section', or we could save a couple more layers.
- add a basic HEALTHCHECK
- remove custom additions to get `gosu`; it's available in the default places now.
- fixed typo :)
- move ENV vars up so we can use them; can't use an ENV in the same section where it is defined, so moved some things around.
- push DEBIAN_FRONTEND into the RUN.