### PR TITLE
test for master_not_discovered_exception

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -136,10 +136,20 @@ else
     CLUSTER_NAME=$(curl -k ${ELASTICSEARCH_URL}/_cat/health?h=cluster 2> /dev/null | tr -d '[:space:]')
     echo "Waiting for Elasticsearch cluster to respond ($counter/30)"
   done
+
   if [ -z "$CLUSTER_NAME" ]; then
     echo "Couldn't get name of cluster. Exiting."
-    echo "Elasticsearch log follows below."
+    echo "Elasticsearch log follows."
     cat /var/log/elasticsearch/elasticsearch.log
+    exit 1
+  elif [[ "$CLUSTER_NAME" =~ "master_not_discovered_exception" ]]; then
+    # If we got a JSON error back, don't treat it like the literal name of the cluster.
+    # Example of what this error looks like:
+    # [{"error":{"root_cause":[{"type":"master_not_discovered_exception","reason":null}]
+    # We don't know the cluster name, so we'll just glob it.
+    echo "Failed to contact a healthy master in cluster."
+    echo "Elasticsearch logs follow."
+    cat /var/log/elasticsearch/*.log
     exit 1
   fi
   OUTPUT_LOGFILES+="/var/log/elasticsearch/${CLUSTER_NAME}.log "


### PR DESCRIPTION
Handle cluster_name fail on startup.  I got tired of seeing the JSON error stuffed into a `tail /var/log/[{json error}]_elasticsearch.log` command. I think this happens more in 7.x as they make discovery smarter.

Fix some grammar while I'm nearby :)