### PR TITLE
Change filebeat.prospectors to filebeat.inputs

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -311,13 +311,13 @@ Here is a sample `/etc/filebeat/filebeat.yml` configuration file for Filebeat, t
 	    enabled: true
 	    hosts:
 	      - elk:5044
-	    ssl:
-		  certificate_authorities:
-      	    - /etc/pki/tls/certs/logstash-beats.crt
 	    timeout: 15
+	    ssl:
+	      certificate_authorities:
+      	      - /etc/pki/tls/certs/logstash-beats.crt
 	
 	filebeat:
-	  prospectors:
+	  inputs:
 	    -
 	      paths:
 	        - /var/log/syslog


### PR DESCRIPTION
Make the example same as sample code. 

Version 7 of Filebeat uses `filebeat.inputs` instead of `filebeat.prospectors`.