### PR TITLE
attempt to mitigate CVE-2021-44228 via JVM flags

### DIFF
--- a/elasticsearch-init
+++ b/elasticsearch-init
@@ -43,7 +43,7 @@ ES_HOME=
 ES_JAVA_HOME=$ES_HOME/jdk
 
 # Additional Java OPTS
-#ES_JAVA_OPTS=
+ES_JAVA_OPTS="-Dlog4j2.formatMsgNoLookups=true"
 
 # Maximum number of open files
 #MAX_OPEN_FILES=65536

--- a/logstash-init
+++ b/logstash-init
@@ -31,7 +31,7 @@ LS_USER=logstash
 LS_GROUP=logstash
 LS_HOME=
 LS_HEAP_SIZE="500m"
-LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME}"
+LS_JAVA_OPTS="-Djava.io.tmpdir=${LS_HOME} -Dlog4j2.formatMsgNoLookups=true"
 LS_LOG_DIR=/var/log/logstash
 LS_LOG_FILE="${LS_LOG_DIR}/${name}-plain.log"
 LS_OPEN_FILES=16384


### PR DESCRIPTION
I believe this should close #360 

I've run and pushed a `docker build` with this change which you can find here: https://hub.docker.com/repository/docker/nathanonboard/elk as `nathanonboard/elk:7.15.2-cve-2021-44228`

I'm testing this now and will report back once I've been able to verify that those two shell flags do what it looks like they should. 